### PR TITLE
Add image gradients instead of concatenating lists

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -7,6 +7,8 @@ import numpy as np
 import pandas as pd
 from torch.utils.data import Dataset, DataLoader
 
+import matplotlib.pyplot as plt
+
 def image_transforms(mode='train', tensor_type='torch.cuda.FloatTensor',
                      augment_parameters=[0.8, 1.2, 0.5, 2.0, 0.8, 1.2],
                      do_augmentation=True, transformations=None):
@@ -15,14 +17,14 @@ def image_transforms(mode='train', tensor_type='torch.cuda.FloatTensor',
             ResizeImage(train=True),
             RandomFlip(do_augmentation),
             ToTensor(tensor_type, train=True),
-            AugmentImagePair(tensor_type, augment_parameters, do_augmentation)
+            AugmentImagePair(augment_parameters, do_augmentation)
         ])
         return data_transform
     elif mode == 'test':
         data_transform = transforms.Compose([
             ResizeImage(train=False),
             ToTensor(tensor_type, train=False),
-            DoTest(tensor_type),
+            DoTest(),
         ])
         return data_transform
     elif mode == 'custom':
@@ -33,7 +35,6 @@ def image_transforms(mode='train', tensor_type='torch.cuda.FloatTensor',
     
     
 class ResizeImage(object):
-
     def __init__(self, train=True):
         self.train = train
         self.transform = transforms.Resize((256, 512))
@@ -52,18 +53,13 @@ class ResizeImage(object):
         return sample
     
 
-class DoTest(object):
-    
-    def __init__(self, tensor_type):
-        self.tensor_type = tensor_type
-        
+class DoTest(object):        
     def __call__(self, sample):
-        new_sample = torch.from_numpy(np.stack((sample, np.fliplr(sample)), 0)).type(self.tensor_type)
-        return new_sample    
+        new_sample = torch.from_numpy(np.stack((sample, np.fliplr(sample)), 0)).type_as(sample)
+        return new_sample
 
     
 class ToTensor(object):
-
     def __init__(self, tensor_type, train):
         self.train = train
         self.transform = transforms.ToTensor()
@@ -84,7 +80,6 @@ class ToTensor(object):
     
     
 class RandomFlip(object):
-
     def __init__(self, do_augmentation):
         self.transform = transforms.RandomHorizontalFlip(p=1)
         self.do_augmentation = do_augmentation
@@ -103,10 +98,8 @@ class RandomFlip(object):
         return sample
     
     
-class AugmentImagePair(object):
- 
-    def __init__(self, tensor_type, augment_parameters, do_augmentation):
-        self.tensor_type = tensor_type
+class AugmentImagePair(object): 
+    def __init__(self, augment_parameters, do_augmentation):
         self.do_augmentation = do_augmentation
         self.gamma_low = augment_parameters[0] #0.8
         self.gamma_high = augment_parameters[1] #1.2
@@ -116,27 +109,26 @@ class AugmentImagePair(object):
         self.color_high = augment_parameters[5] #1.2
 
     def __call__(self, sample):
-        left_image = sample['left_image'].type(self.tensor_type)
-        right_image = sample['right_image'].type(self.tensor_type)
+        left_image = sample['left_image']
+        right_image = sample['right_image']
         p = np.random.uniform(0, 1, 1)
         if self.do_augmentation:
             if p > 0.5:
                 # randomly shift gamma
-                random_gamma = torch.from_numpy(np.random.uniform(self.gamma_low, self.gamma_high, 1)).type(self.tensor_type)
+                random_gamma = np.random.uniform(self.gamma_low, self.gamma_high)
                 left_image_aug  = left_image  ** random_gamma
                 right_image_aug = right_image ** random_gamma
 
                 # randomly shift brightness
-                random_brightness =  torch.from_numpy(np.random.uniform(self.brightness_low, self.brightness_high, 1)).type(self.tensor_type)
+                random_brightness = np.random.uniform(self.brightness_low, self.brightness_high)
                 left_image_aug  =  left_image_aug * random_brightness
                 right_image_aug = right_image_aug * random_brightness
 
                 # randomly shift color
-                random_colors =  torch.from_numpy(np.random.uniform(self.color_low, self.color_high, 3)).type(self.tensor_type)
-                white = torch.ones([np.shape(left_image)[1], np.shape(left_image)[2]]).type(self.tensor_type)
-                color_image = torch.stack([white * random_colors[i] for i in range(3)], dim=0)
-                left_image_aug  *= color_image
-                right_image_aug *= color_image
+                random_colors = np.random.uniform(self.color_low, self.color_high, 3)
+                for i in range(3):
+                    left_image_aug[i,:,:] *= random_colors[i]
+                    right_image_aug[i,:,:] *= random_colors[i]
 
                 # saturate
                 left_image_aug  = torch.clamp(left_image_aug,  0, 1)

--- a/loss.py
+++ b/loss.py
@@ -5,14 +5,12 @@ import torch.nn.functional as F
 
 
 class MonodepthLoss(nn.modules.Module):
-    def __init__(self, n=4, SSIM_w=0.85, disp_gradient_w=1.0, lr_w=1.0,
-                 tensor_type='torch.cuda.FloatTensor'):
+    def __init__(self, n=4, SSIM_w=0.85, disp_gradient_w=1.0, lr_w=1.0):
         super(MonodepthLoss, self).__init__()
         self.SSIM_w = SSIM_w
         self.disp_gradient_w = disp_gradient_w
         self.lr_w = lr_w
         self.n = n
-        self.tensor_type = tensor_type
 
     def scale_pyramid(self, img, num_scales):
         scaled_imgs = [img]
@@ -35,13 +33,12 @@ class MonodepthLoss(nn.modules.Module):
         gy = img[:,:,:-1,:] - img[:,:,1:,:]  # NCHW
         return gy
 
-<<<<<<< c10c5c0f8bf3d8fe9ec5bb6df2d6236a7ff64a8e
-    def apply_disparity(self, img, disp, tensor_type='torch.cuda.FloatTensor'):
+    def apply_disparity(self, img, disp):
         batch_size, _, height, width = img.size()
         
         # Original coordinates of pixels
-        x_base = torch.linspace(-1, 1, width).repeat(batch_size, height, 1).type(tensor_type)
-        y_base = torch.linspace(-1, 1, height).repeat(batch_size, width, 1).transpose(1, 2).type(tensor_type)
+        x_base = torch.linspace(-1, 1, width).repeat(batch_size, height, 1).type_as(img)
+        y_base = torch.linspace(-1, 1, height).repeat(batch_size, width, 1).transpose(1, 2).type_as(img)
 
         # Apply shift in X direction
         x_shifts = disp[:,0,:,:] # Disparity is passed in NCHW format with 1 channel
@@ -50,18 +47,11 @@ class MonodepthLoss(nn.modules.Module):
 
         return output
 
-    def generate_image_left(self, img, disp, tensor_type):
-        return self.apply_disparity(img, -disp, tensor_type=tensor_type)
-
-    def generate_image_right(self, img, disp, tensor_type):
-        return self.apply_disparity(img, disp, tensor_type=tensor_type)
-=======
     def generate_image_left(self, img, disp):
-        return apply_disparity(img, -disp, tensor_type=self.tensor_type)
+        return self.apply_disparity(img, -disp)
 
     def generate_image_right(self, img, disp):
-        return apply_disparity(img, disp, tensor_type=self.tensor_type)
->>>>>>> fix: Passing tensor and device types between functions
+        return self.apply_disparity(img, disp)
 
     def SSIM(self, x, y):
         C1 = 0.01 ** 2

--- a/loss.py
+++ b/loss.py
@@ -94,7 +94,8 @@ class MonodepthLoss(nn.modules.Module):
         smoothness_y = [disp_gradients_y[i] * weights_y[i]\
                         for i in range(self.n)]
 
-        return [smoothness_x[i] + smoothness_y[i] for i in range(self.n)]
+        return [torch.abs(smoothness_x[i]) + torch.abs(smoothness_y[i])
+                for i in range(self.n)]
 
     def forward(self, input, target):
         """

--- a/loss.py
+++ b/loss.py
@@ -26,10 +26,14 @@ class MonodepthLoss(nn.modules.Module):
         return scaled_imgs
 
     def gradient_x(self, img):
+        # Pad input to keep output size consistent
+        img = F.pad(img, (0, 1, 0, 0), mode="replicate")
         gx = img[:,:,:,:-1] - img[:,:,:,1:]  # NCHW
         return gx
 
     def gradient_y(self, img):
+        # Pad input to keep output size consistent
+        img = F.pad(img, (0, 0, 0, 1), mode="replicate")
         gy = img[:,:,:-1,:] - img[:,:,1:,:]  # NCHW
         return gy
 
@@ -90,7 +94,7 @@ class MonodepthLoss(nn.modules.Module):
         smoothness_y = [disp_gradients_y[i] * weights_y[i]\
                         for i in range(self.n)]
 
-        return smoothness_x + smoothness_y
+        return [smoothness_x[i] + smoothness_y[i] for i in range(self.n)]
 
     def forward(self, input, target):
         """

--- a/main_monodepth_pytorch.py
+++ b/main_monodepth_pytorch.py
@@ -121,7 +121,7 @@ class Model:
                     do_augmentation=args.do_augmentation)
             train_datasets = [KittiLoader(os.path.join(args.data_dir,
                               data_dir), True,
-                              transform=data_transform) for data_dir i  
+                              transform=data_transform) for data_dir in
                               data_dirs]
             train_dataset = ConcatDataset(train_datasets)
             self.n_img = len(train_dataset)
@@ -136,8 +136,7 @@ class Model:
             self.loss_function = MonodepthLoss(
                     n=4,
                     SSIM_w=0.85,
-                    disp_gradient_w=0.1, lr_w=1,
-                    tensor_type=args.tensor_type).to(self.device)
+                    disp_gradient_w=0.1, lr_w=1).to(self.device)
             if args.model == 'resnet50_md':
                 self.model = models_resnet.resnet50_md(3)
             elif args.model == 'resnet18_md':
@@ -182,8 +181,8 @@ class Model:
             c_time = time.time()
             for data in self.train_loader:
                 # Load data
-                left = data['left_image'].to(self.device)
-                right = data['right_image'].to(self.device)
+                left = data['left_image']
+                right = data['right_image']
 
                 # One optimization iteration
                 self.optimizer.zero_grad()
@@ -265,17 +264,17 @@ class Model:
                                   self.input_height, self.input_width),
                                   dtype=np.float32)
         with torch.no_grad():
-            for (i, data) in enumerate(self.test_loader, 0):
+            for (i, data) in enumerate(self.test_loader):
                 # Get the inputs
                 left = data.squeeze()
-                left = left.to(self.device)
 
                 # Do a forward pass
+                # print(left.type())
                 disps = self.model(left)
                 disp = disps[0][:, 0, :, :].unsqueeze(1)
                 disparities[i] = disp[0].squeeze()
                 disparities_pp[i] = \
-                    post_process_disparity(disp.squeeze().numpy())
+                    post_process_disparity(disp.squeeze().cpu().numpy())
 
         np.save(self.output_directory + '/disparities.npy', disparities)
         np.save(self.output_directory + '/disparities_pp.npy',
@@ -295,3 +294,4 @@ def main(args):
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
The X and Y-direction image gradients for computing smoothness were being concatenated instead of actually summed (as given in the smoothness loss in the Godard paper). This PR sums the gradients, while also adding a single-pixel padding in the X and Y directions when computing the gradients so that the tensors are the correct sizes.