### PR TITLE
Update scale_pyramid with area downsampling

### DIFF
--- a/loss.py
+++ b/loss.py
@@ -21,8 +21,8 @@ class MonodepthLoss(nn.modules.Module):
             nh = h // ratio
             nw = w // ratio
             scaled_imgs.append(nn.functional.interpolate(img,
-                               size=[nh, nw], mode='bilinear',
-                               align_corners=True))
+                               size=[nh, nw], mode="area",
+                               align_corners=None))
         return scaled_imgs
 
     def gradient_x(self, img):


### PR DESCRIPTION
Replace bilinear with area interpolation for the scale pyramid as suggested in the official implementation https://github.com/mrharicot/monodepth/blob/5bc4bb1eaf6f6c78ec3bcda37af4eeea9fc4f0c6/monodepth_model.py#L82